### PR TITLE
Term id is not required anymore in Stackla's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Property | type | value | Post | Put | Definition
 id | ```string``` |  | ✘ | ✘ | Unique identifier for the Tile, in the Stack. This is an object containing a "$id" property, which will expose the ID as a 24-byte string
 sta_feed_id | ```string``` | | ✔ | ✘ | Globally unique ID to be used for this post (often referencing external ID)
 guid | ```string``` | | ✔ | ✘ | Globally unique ID to be used for this post (often referencing external ID)
+term_id | ```integer``` | | ✔ | ✘ | Associated term (optional)
 name | ```string``` | | ✔ | ✘ | Display name to be used for the author
 avatar | ```string``` | | ✔ | ✘ | URL to be used as the post author's avatar
 title | ```string``` | | ✔ | ✘ | Tile title to accompany the message, often used for video tiles

--- a/src/Stackla/Api/Tile.php
+++ b/src/Stackla/Api/Tile.php
@@ -570,7 +570,9 @@ class Tile extends StacklaModel implements TileInterface
     public function create()
     {
         $endpoint = sprintf("%s?", $this->endpoint);
-
+        if(isset($this->term_id) && !is_null($this->term_id)) {
+            $endpoint = sprintf("%s?term_id=%s", $this->endpoint, $this->term_id);
+        }
         $data = $this->toArray(true);
         unset($data['term_id']);
 

--- a/src/Stackla/Api/Tile.php
+++ b/src/Stackla/Api/Tile.php
@@ -569,11 +569,7 @@ class Tile extends StacklaModel implements TileInterface
 
     public function create()
     {
-        if (empty($this->term_id)) {
-            throw new \Exception('Tile creation require Stackla type term id ');
-        }
-
-        $endpoint = sprintf("%s?term_id=%s", $this->endpoint, $this->term_id);
+        $endpoint = sprintf("%s?", $this->endpoint);
 
         $data = $this->toArray(true);
         unset($data['term_id']);


### PR DESCRIPTION
I removed SDK restriction.
